### PR TITLE
Add .npmrc file for CIP Pool PCs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+prefix = ${HOME}/.npmpackages


### PR DESCRIPTION
The .npmrc file should be put directly into the home directory of the CIP pool user to allow global npm installs.
