### PR TITLE
Fix missing dependency for mongodb

### DIFF
--- a/assignment09/skeleton/NotesApp/package.json
+++ b/assignment09/skeleton/NotesApp/package.json
@@ -12,6 +12,7 @@
     "debug": "~2.2.0",
     "express": "~4.13.1",
     "jade": "~1.11.0",
+    "mongodb": "^1.4.4",
     "monk": "^1.0.1",
     "morgan": "~1.6.1",
     "serve-favicon": "~2.3.0"


### PR DESCRIPTION
Monk needs mongoskin which in turn depends on mongodb.
Installing version 1.4 explicitly fixes this mismatch.

Fixes #12
